### PR TITLE
AIR-480 Upgrades to resolve security vulnerabilities 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache --virtual build-dependencies build-base=~0.5 && \
     make clean && \
     make build
 
-FROM alpine:3
+FROM alpine:latest
 COPY --from=builder /usr/src/sriov-cni/build/sriov /usr/bin/
 WORKDIR /
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ TESTPKGS = $(shell env GOPATH=$(GOPATH) $(GO) list -f '{{ if or .TestGoFiles .XT
 SRCROOT = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/)
 BUILD_ROOT = $(SRCROOT)/build
 
-UPSTREAM_VERSION=$(shell git describe --tags HEAD)
+UPSTREAM_VERSION=$(shell git describe --tags HEAD |  sed 's/-.*//')
 registry_url ?= 514845858982.dkr.ecr.us-west-1.amazonaws.com
 #registry_url ?= docker.io
 

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ SRCROOT = $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/)
 BUILD_ROOT = $(SRCROOT)/build
 
 UPSTREAM_VERSION=$(shell git describe --tags HEAD |  sed 's/-.*//')
-registry_url ?= 514845858982.dkr.ecr.us-west-1.amazonaws.com
-#registry_url ?= docker.io
+#registry_url ?= 514845858982.dkr.ecr.us-west-1.amazonaws.com
+registry_url ?= docker.io
 
 image_name = ${registry_url}/platform9/sriov-cni
 image_tag = $(UPSTREAM_VERSION)-pmk-$(TEAMCITY_BUILD_ID)
@@ -157,12 +157,8 @@ pf9-image: | $(BASE) ; $(info Building Docker image for pf9 Repo...) @ ## Build 
 	@docker build -t $(PF9_TAG) -f $(DOCKERFILE)  $(CURDIR) $(DOCKERARGS)
 
 pf9-push:
-	docker push $(PF9_TAG) \
-	&& docker rmi $(PF9_TAG)
-	(docker push $(PF9_TAG)  || \
-		(aws ecr get-login --region=us-west-1 --no-include-email | sh && \
-		docker push $(PF9_TAG))) && \
-		docker rmi $(PF9_TAG)
+	docker push $(PF9_TAG) && \
+	docker rmi $(PF9_TAG)
 
 scan:
 	docker run -v $(BUILD_ROOT)/luigi:/out -v /var/run/docker.sock:/var/run/docker.sock -v $(HOME)/.trivy:/root/.cache  aquasec/trivy image -s CRITICAL,HIGH -f json  --vuln-type library -o /out/library_vulnerabilities.json --exit-code 22 ${PF9_TAG}


### PR DESCRIPTION
## ISSUE:
[AIR-480](https://platform9.atlassian.net/jira/software/c/projects/AIR/boards/116?modal=detail&selectedIssue=AIR-480)

## SUMMARY:
Moved to alpine:latest, to resolve security vulnerabilities, so that even if new vulnerabilities arise, they're being actively resolved in alpine latest version. 
Built the image locally, running trivy scan on the image shows no vulnerabilities:
```
trivy image  -s CRITICAL,HIGH --exit-code 22 platform9/sriov-cni:v2.6.2-pmk-
2022-11-23T13:35:32.351Z	INFO	Vulnerability scanning is enabled
2022-11-23T13:35:32.351Z	INFO	Secret scanning is enabled
2022-11-23T13:35:32.352Z	INFO	If your scanning is slow, please try '--security-checks vuln' to disable secret scanning
2022-11-23T13:35:32.352Z	INFO	Please see also https://aquasecurity.github.io/trivy/0.30.1/docs/secret/scanning/#recommendation for faster secret detection
2022-11-23T13:35:32.372Z	INFO	Detected OS: alpine
2022-11-23T13:35:32.372Z	INFO	Detecting Alpine vulnerabilities...
2022-11-23T13:35:32.373Z	INFO	Number of language-specific files: 1
2022-11-23T13:35:32.373Z	INFO	Detecting gobinary vulnerabilities...
```
Also added support for sriov-cni local branch build along with pf9 pmk versioning with teamcity build numbers. New version format for pf9 local builds looks like:
<registry>/platform9/<repo>:<upstream forked version>-pmk-<TC_BUILD_ID>
The resulting versioned image is then uploaded to ECR/docker.

[This](https://teamcity.platform9.horse/viewLog.html?buildId=2353472&buildTypeId=Pf9project_Platform9ComponentsForKubernetes_SriovCni&tab=buildLog&_focus=710#_state=710) is the succesful TC build, which runs a trivy scan on the image, shows no vulnerabilities 